### PR TITLE
Добавлена запись контекста в класс UsbPrinterPort

### DIFF
--- a/Source/android/tinyJavaPosTester/src/com/shtrih/tinyjavapostester/MainActivity.java
+++ b/Source/android/tinyJavaPosTester/src/com/shtrih/tinyjavapostester/MainActivity.java
@@ -1642,6 +1642,8 @@ public class MainActivity extends AppCompatActivity
 
         log.debug("Found " + usbs.size() + " USB devices");
 
+        UsbPrinterPort.Context = this;
+        
         int deviceId = usbs.get(0).getDevice().getDeviceId();
         ConnectionParameters params = getParams();
         params.portName = String.format(Locale.ENGLISH, "%d", deviceId);


### PR DESCRIPTION
Без записи контекста, UsbManager не мог инициализироваться